### PR TITLE
Virtual Device Driver Sanity check

### DIFF
--- a/src/Aporta.WebClient/Pages/configuration/People.razor
+++ b/src/Aporta.WebClient/Pages/configuration/People.razor
@@ -98,7 +98,7 @@ else
         <ModalContent Size="ModalSize.Default" Centered="true">
             <ModalHeader>
                 <ModalTitle>
-                    Add Door
+                    Add Person
                 </ModalTitle>
                 <CloseButton Clicked="@_addPersonModal.Hide"/>
             </ModalHeader>

--- a/src/Drivers/Aporta.Drivers.Virtual.Shared/Actions/ActionType.cs
+++ b/src/Drivers/Aporta.Drivers.Virtual.Shared/Actions/ActionType.cs
@@ -1,0 +1,10 @@
+﻿using Aporta.Shared.Models;
+
+namespace Aporta.Drivers.Virtual.Shared.Actions
+{
+    public enum ActionType
+    {
+        [Description("Badge Swipe")]
+        BadgeSwipe
+    }
+}

--- a/src/Drivers/Aporta.Drivers.Virtual.Shared/Actions/BadgeSwipeAction.cs
+++ b/src/Drivers/Aporta.Drivers.Virtual.Shared/Actions/BadgeSwipeAction.cs
@@ -1,0 +1,8 @@
+﻿namespace Aporta.Drivers.Virtual.Shared.Actions;
+
+public class BadgeSwipeAction
+{
+    public byte ReaderNumber { get; set; }
+    public string CardData { get; set; }
+}
+

--- a/src/Drivers/Aporta.Drivers.Virtual.Shared/Aporta.Drivers.Virtual.Shared.csproj
+++ b/src/Drivers/Aporta.Drivers.Virtual.Shared/Aporta.Drivers.Virtual.Shared.csproj
@@ -7,10 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <Folder Include="Actions\" />
-    </ItemGroup>
-
-    <ItemGroup>
       <ProjectReference Include="..\..\Aporta.Shared\Aporta.Shared.csproj" />
     </ItemGroup>
 

--- a/src/Drivers/Aporta.Drivers.Virtual.Shared/Aporta.Drivers.Virtual.Shared.csproj
+++ b/src/Drivers/Aporta.Drivers.Virtual.Shared/Aporta.Drivers.Virtual.Shared.csproj
@@ -6,4 +6,12 @@
         <LangVersion>default</LangVersion>
     </PropertyGroup>
 
+    <ItemGroup>
+      <Folder Include="Actions\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\Aporta.Shared\Aporta.Shared.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/src/Drivers/Aporta.Drivers.Virtual.WebClient/Aporta.Drivers.Virtual.WebClient.csproj
+++ b/src/Drivers/Aporta.Drivers.Virtual.WebClient/Aporta.Drivers.Virtual.WebClient.csproj
@@ -16,6 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\Aporta.Shared\Aporta.Shared.csproj" />
       <ProjectReference Include="..\Aporta.Drivers.Virtual.Shared\Aporta.Drivers.Virtual.Shared.csproj" />
     </ItemGroup>
 </Project>

--- a/src/Drivers/Aporta.Drivers.Virtual.WebClient/Configuration.razor
+++ b/src/Drivers/Aporta.Drivers.Virtual.WebClient/Configuration.razor
@@ -1,30 +1,101 @@
-﻿@using Newtonsoft.Json
+﻿@using Blazorise.Snackbar
+@using Newtonsoft.Json
+
+@using Aporta.Shared.Calls
+@using Aporta.Shared.Models
+@using Aporta.Drivers.Virtual.Shared
+@using Aporta.Drivers.Virtual.Shared.Actions
+
+
+@inject IDriverConfigurationCalls ConfigurationCalls;
 
 @if (_configuration == null)
 {
-    <div class="spinner"></div>
+    <div class="spinner">Config Not Set</div>
 }
 else
 {
     <Text>Setup</Text>
 
-    <MessageProvider/>
+
+    <Table Narrow="true" Hoverable="true" ThemeContrast="ThemeContrast.Light">
+        <TableHeader>
+            <TableRow>
+                <TableHeaderCell>Reader Name</TableHeaderCell>
+                <TableHeaderCell>Reader Number</TableHeaderCell>
+                <TableHeaderCell>Badge Number</TableHeaderCell>
+            </TableRow>
+        </TableHeader>
+        <TableBody>
+            @foreach (var device in _configuration.Readers)
+            {
+                <TableRow ElementId="@("Device:" + @device.Name)">
+                    <TableRowHeader>
+                        @device.Name
+                    </TableRowHeader>
+                    <TableRowCell>
+                        @device.Number
+                    </TableRowCell>
+                    <TableRowCell>
+                        <Button Clicked="@(async () => await PerformAction( ActionType.BadgeSwipe, "12345" ))">Click to Simulate Badge Swipe</Button>
+                    </TableRowCell>
+                </TableRow>
+            }
+        </TableBody>
+    </Table>
+
+    <Snackbar @ref="_snackbar" Color="@_snackbarColor">
+        <SnackbarBody>
+            @_snackbarMessage
+        </SnackbarBody>
+    </Snackbar>
+
+    <MessageProvider />
 }
 
 @code {
-    [Inject] 
+    [Inject]
     IMessageService MessageService { get; set; }
-    
+
     private Aporta.Drivers.Virtual.Shared.Configuration _configuration;
-    
+
+    private Snackbar _snackbar;
+    private SnackbarColor _snackbarColor;
+    private string _snackbarMessage = string.Empty;
+
+
+
     [Parameter]
     public Guid ExtensionId { get; set; }
 
     [Parameter]
     public string RawConfiguration { get; set; }
-    
+
     protected override void OnParametersSet()
     {
         _configuration = JsonConvert.DeserializeObject<Aporta.Drivers.Virtual.Shared.Configuration>(RawConfiguration);
     }
+
+    private async Task<string> PerformAction(ActionType actionType, string parameters)
+    {
+        string responseData;
+        try
+        {
+            responseData = await ConfigurationCalls.PerformAction(ExtensionId, actionType.ToString(), parameters);
+        }
+        catch (Exception exception)
+        {
+            _snackbarMessage = $"Unable to perform action {actionType.GetDescription()}. {exception.Message}";
+            _snackbarColor = SnackbarColor.Danger;
+            if (_snackbar != null) await _snackbar.Show();
+            return string.Empty;
+        }
+
+        _snackbarMessage = $"Request to perform action {actionType.GetDescription()} successfully sent";
+        _snackbarColor = SnackbarColor.Info;
+        if (_snackbar != null) await _snackbar.Show();
+
+        return responseData;
+    }
+
 }

--- a/src/Drivers/Aporta.Drivers.Virtual.WebClient/Configuration.razor
+++ b/src/Drivers/Aporta.Drivers.Virtual.WebClient/Configuration.razor
@@ -36,10 +36,10 @@ else
                         @device.Number
                     </TableRowCell>
                     <TableRowCell>
-                        <TextEdit @bind-Text="_badgeNumbers[device.Number]"></TextEdit>
+                        <TextEdit Width="Width.Px(300)" @bind-Text="_badgeNumbers[device.Number]"></TextEdit>
                     </TableRowCell>
                     <TableRowCell>
-                        <Button Clicked="@(async () => await SwipeBadge(device.Number))">Click to Simulate Badge Swipe</Button>
+                        <Button Color="Color.Primary" Clicked="@(async () => await SwipeBadge(device.Number))">Click to Simulate Badge Swipe</Button>
                     </TableRowCell>
                 </TableRow>
             }

--- a/src/Drivers/Aporta.Drivers.Virtual.WebClient/Configuration.razor
+++ b/src/Drivers/Aporta.Drivers.Virtual.WebClient/Configuration.razor
@@ -4,9 +4,7 @@
 @using Aporta.Shared.Models
 @using Aporta.Drivers.Virtual.Shared
 @using Aporta.Drivers.Virtual.Shared.Actions
-@* @using Microsoft.JSInterop; *@
 
-@* @inject IJSRuntime JSRuntime; *@
 @inject IDriverConfigurationCalls ConfigurationCalls;
 
 @if (_configuration == null)
@@ -38,10 +36,10 @@ else
                         @device.Number
                     </TableRowCell>
                     <TableRowCell>
-                        <TextEdit ElementId="@($"txtReaderNumber{device.Number}")"></TextEdit>
+                        <TextEdit @bind-Text="_badgeNumbers[device.Number]"></TextEdit>
                     </TableRowCell>
                     <TableRowCell>
-                        <Button Clicked="@(async () => await SwipeBadge(device.Number, "12345" ))">Click to Simulate Badge Swipe (12345 badge number currently hard coded)</Button>
+                        <Button Clicked="@(async () => await SwipeBadge(device.Number))">Click to Simulate Badge Swipe</Button>
                     </TableRowCell>
                 </TableRow>
             }
@@ -67,7 +65,7 @@ else
     private SnackbarColor _snackbarColor;
     private string _snackbarMessage = string.Empty;
 
-
+    private Dictionary<byte, string> _badgeNumbers;
 
     [Parameter]
     public Guid ExtensionId { get; set; }
@@ -78,20 +76,27 @@ else
     protected override void OnParametersSet()
     {
         _configuration = JsonConvert.DeserializeObject<Aporta.Drivers.Virtual.Shared.Configuration>(RawConfiguration);
+
+        _badgeNumbers = new Dictionary<byte, string>();
+
+        LoadBadgeNumberBindings();
     }
 
 
-    private async Task<string> SwipeBadge(byte readerNumber, string cardData)
+    private void LoadBadgeNumberBindings()
     {
+        foreach (var device in _configuration.Readers)
+        {
+            _badgeNumbers.Add(device.Number, string.Empty);
+        }
+    }
 
-        //experiment to try to retrieve the value of the card number typed in by a user for a badge swipe...
-        //var txtCardNumber = await JSRuntime.InvokeAsync<ElementReference>("document.getElementById", $"txtReaderNumber{readerNumber}");
-        // cardData = txtCardNumber.value;
-
+    private async Task<string> SwipeBadge(byte readerNumber)
+    {
         var parameters = JsonConvert.SerializeObject(new BadgeSwipeAction
             {
                 ReaderNumber = readerNumber,
-                CardData = cardData
+                CardData = _badgeNumbers[readerNumber]
             });
 
         return await PerformAction(ActionType.BadgeSwipe, parameters);

--- a/src/Drivers/Aporta.Drivers.Virtual.WebClient/Configuration.razor
+++ b/src/Drivers/Aporta.Drivers.Virtual.WebClient/Configuration.razor
@@ -4,7 +4,7 @@
 @using Aporta.Shared.Models
 @using Aporta.Drivers.Virtual.Shared
 @using Aporta.Drivers.Virtual.Shared.Actions
-@using Microsoft.JSInterop;
+@* @using Microsoft.JSInterop; *@
 
 @* @inject IJSRuntime JSRuntime; *@
 @inject IDriverConfigurationCalls ConfigurationCalls;

--- a/src/Drivers/Aporta.Drivers.Virtual.WebClient/Configuration.razor
+++ b/src/Drivers/Aporta.Drivers.Virtual.WebClient/Configuration.razor
@@ -4,8 +4,9 @@
 @using Aporta.Shared.Models
 @using Aporta.Drivers.Virtual.Shared
 @using Aporta.Drivers.Virtual.Shared.Actions
+@using Microsoft.JSInterop;
 
-
+@* @inject IJSRuntime JSRuntime; *@
 @inject IDriverConfigurationCalls ConfigurationCalls;
 
 @if (_configuration == null)
@@ -23,6 +24,7 @@ else
                 <TableHeaderCell>Reader Name</TableHeaderCell>
                 <TableHeaderCell>Reader Number</TableHeaderCell>
                 <TableHeaderCell>Badge Number</TableHeaderCell>
+                <TableHeaderCell></TableHeaderCell>
             </TableRow>
         </TableHeader>
         <TableBody>
@@ -36,7 +38,10 @@ else
                         @device.Number
                     </TableRowCell>
                     <TableRowCell>
-                        <Button Clicked="@(async () => await SwipeBadge(device.Number, "12345" ))">Click to Simulate Badge Swipe</Button>
+                        <TextEdit ElementId="@($"txtReaderNumber{device.Number}")"></TextEdit>
+                    </TableRowCell>
+                    <TableRowCell>
+                        <Button Clicked="@(async () => await SwipeBadge(device.Number, "12345" ))">Click to Simulate Badge Swipe (12345 badge number currently hard coded)</Button>
                     </TableRowCell>
                 </TableRow>
             }
@@ -78,6 +83,11 @@ else
 
     private async Task<string> SwipeBadge(byte readerNumber, string cardData)
     {
+
+        //experiment to try to retrieve the value of the card number typed in by a user for a badge swipe...
+        //var txtCardNumber = await JSRuntime.InvokeAsync<ElementReference>("document.getElementById", $"txtReaderNumber{readerNumber}");
+        // cardData = txtCardNumber.value;
+
         var parameters = JsonConvert.SerializeObject(new BadgeSwipeAction
             {
                 ReaderNumber = readerNumber,
@@ -92,17 +102,6 @@ else
         string responseData;
         try
         {
-
-
-
-            // var badgeAction = JsonSerializer.Serialize(new EventData
-            //     {
-            //         Door = matchingDoor,
-            //         Endpoint = accessPoint,
-            //         EventReason = EventReason.CredentialNotEnrolled,
-            //         CardNumber = matchingCardData
-            //     });
-
             responseData = await ConfigurationCalls.PerformAction(ExtensionId, actionType.ToString(), parameters);
         }
         catch (Exception exception)

--- a/src/Drivers/Aporta.Drivers.Virtual.WebClient/Configuration.razor
+++ b/src/Drivers/Aporta.Drivers.Virtual.WebClient/Configuration.razor
@@ -1,6 +1,5 @@
 ﻿@using Blazorise.Snackbar
 @using Newtonsoft.Json
-
 @using Aporta.Shared.Calls
 @using Aporta.Shared.Models
 @using Aporta.Drivers.Virtual.Shared
@@ -37,7 +36,7 @@ else
                         @device.Number
                     </TableRowCell>
                     <TableRowCell>
-                        <Button Clicked="@(async () => await PerformAction( ActionType.BadgeSwipe, "12345" ))">Click to Simulate Badge Swipe</Button>
+                        <Button Clicked="@(async () => await SwipeBadge(device.Number, "12345" ))">Click to Simulate Badge Swipe</Button>
                     </TableRowCell>
                 </TableRow>
             }
@@ -76,11 +75,34 @@ else
         _configuration = JsonConvert.DeserializeObject<Aporta.Drivers.Virtual.Shared.Configuration>(RawConfiguration);
     }
 
+
+    private async Task<string> SwipeBadge(byte readerNumber, string cardData)
+    {
+        var parameters = JsonConvert.SerializeObject(new BadgeSwipeAction
+            {
+                ReaderNumber = readerNumber,
+                CardData = cardData
+            });
+
+        return await PerformAction(ActionType.BadgeSwipe, parameters);
+    }
+
     private async Task<string> PerformAction(ActionType actionType, string parameters)
     {
         string responseData;
         try
         {
+
+
+
+            // var badgeAction = JsonSerializer.Serialize(new EventData
+            //     {
+            //         Door = matchingDoor,
+            //         Endpoint = accessPoint,
+            //         EventReason = EventReason.CredentialNotEnrolled,
+            //         CardNumber = matchingCardData
+            //     });
+
             responseData = await ConfigurationCalls.PerformAction(ExtensionId, actionType.ToString(), parameters);
         }
         catch (Exception exception)

--- a/src/Drivers/Aporta.Drivers.Virtual/Docs/HowToUseTheVirtualDeviceDriver.md
+++ b/src/Drivers/Aporta.Drivers.Virtual/Docs/HowToUseTheVirtualDeviceDriver.md
@@ -1,0 +1,40 @@
+﻿# How to Use the Virtual Device Driver
+
+## Virtual Device Configuration
+<ol>
+  <li>Under the Configuration menu, select Hardware->Drivers.</li>
+  <li>Enable the Virtual Device Driver.</li>
+</ol>
+
+## Assign the Virtual Device to a door
+<ol>
+  <li>Under the Configuration menu, select Hardware->Doors.</li>
+  <li>Add a new door.</li>
+  <li>Assign the door to the Virtual Device reader and output.
+</ol>
+
+## Simulate a badge swipe
+<ol>
+  <li>Under the Configuration menu, select Hardware->Drivers.</li>
+  <li>Click on the row for the Virtual Device Driver.</li>
+  <li>The configuration page for the Virtual Device Driver will open.</li>
+  <li>A list of virtual readers assigned to the Virtual Device Driver will be displayed.
+	<ul>
+		<li>Each record in this list provides a text field to key in a hypothetical badge number, and a button that 
+		when clicked will simulate swiping a badge that holds that number.
+		</li>
+		<li>
+		A record of the badge swipe will be written to a log. You can see a history of badge swipes on the Monitoring page.
+		</li>
+		<li>
+		Records of badge swipes using badge numbers not yet assigned to a person in the system will show "Credential Not Enrolled".
+		</li>
+		<li>
+		To enroll a person in the system with a badge, follow the Quck Start Guide instructions. 
+		</li>
+	</ul>
+  </li>
+</ol>
+
+[Quck Start Guide instructions](https://github.com/bytedreamer/Aporta/wiki/Quick-start-guide)
+  

--- a/src/Drivers/Aporta.Drivers.Virtual/VirtualDriver.cs
+++ b/src/Drivers/Aporta.Drivers.Virtual/VirtualDriver.cs
@@ -114,12 +114,9 @@ public class VirtualDriver : IHardwareDriver
             .SingleOrDefault(accessPoint =>
                 $"VR{badgeAction.ReaderNumber}" == accessPoint.Id);
 
-
-        var cardID = badgeAction.CardData.ToBitArray();
-
         AccessCredentialReceived?.Invoke(this,
             new AccessCredentialReceivedEventArgs(
-                accessPoint, new TestCredentialReceivedHandler(cardID)));
+                accessPoint, new VirtualCredentialReceivedHandler(badgeAction.CardData.ToBitArray())));
 
 
     }
@@ -153,7 +150,7 @@ public class VirtualDriver : IHardwareDriver
         OnlineStatusChanged?.Invoke(this, eventArgs);
     }
 
-    internal class TestCredentialReceivedHandler(BitArray cardData) : ICredentialReceivedHandler
+    internal class VirtualCredentialReceivedHandler(BitArray cardData) : ICredentialReceivedHandler
     {
         public bool IsValid()
         {

--- a/src/Drivers/Aporta.Drivers.Virtual/VirtualDriver.cs
+++ b/src/Drivers/Aporta.Drivers.Virtual/VirtualDriver.cs
@@ -33,6 +33,8 @@ public class VirtualDriver : IHardwareDriver
         _logger = loggerFactory.CreateLogger<VirtualDriver>();
         
         _configuration.Readers.Add(new Reader{Name = "Virtual Reader 1", Number = 1});
+        _configuration.Readers.Add(new Reader { Name = "Virtual Reader 2", Number = 2 });
+        _configuration.Readers.Add(new Reader { Name = "Virtual Reader 3", Number = 3 });
         foreach (var reader in _configuration.Readers)
         {
             _endpoints.Add(new VirtualReader(reader.Name, Id, $"VR{reader.Number}"));
@@ -45,7 +47,6 @@ public class VirtualDriver : IHardwareDriver
         }
         
         _configuration.Inputs.Add(new Input{Name = "Virtual Input 1", Number = 1});
-        _configuration.Inputs.Add(new Input{Name = "Virtual Input 1", Number = 2});
         foreach (var input in _configuration.Inputs)
         {
             _endpoints.Add(new VirtualInput(input.Name, Id, $"VI{input.Number}"));

--- a/src/Drivers/Aporta.Drivers.Virtual/VirtualDriver.cs
+++ b/src/Drivers/Aporta.Drivers.Virtual/VirtualDriver.cs
@@ -84,17 +84,7 @@ public class VirtualDriver : IHardwareDriver
                 {
                     case ActionType.BadgeSwipe:
 
-                        _logger.LogInformation("A card has been presented to the reader");
-                        var accessPoint = _endpoints.Where(endpoint => endpoint is IAccess).Cast<IAccess>()
-                            .SingleOrDefault(accessPoint =>
-                                "VR1" == accessPoint.Id);
-
-
-                        var cardID = parameters.ToBitArray();
-
-                        AccessCredentialReceived?.Invoke(this,
-                            new AccessCredentialReceivedEventArgs(
-                                accessPoint, new TestCredentialReceivedHandler(cardID)));
+                        ProcessBadgeSwipe(parameters);
 
                         break;
 
@@ -111,6 +101,26 @@ public class VirtualDriver : IHardwareDriver
         }
 
         return Task.FromResult(string.Empty);
+
+    }
+
+    private void ProcessBadgeSwipe(string parameters)
+    {
+        var badgeAction = JsonConvert.DeserializeObject<BadgeSwipeAction>(parameters);
+        if (badgeAction == null) return;
+
+        _logger.LogInformation("A card has been presented to the reader");
+        var accessPoint = _endpoints.Where(endpoint => endpoint is IAccess).Cast<IAccess>()
+            .SingleOrDefault(accessPoint =>
+                $"VR{badgeAction.ReaderNumber}" == accessPoint.Id);
+
+
+        var cardID = badgeAction.CardData.ToBitArray();
+
+        AccessCredentialReceived?.Invoke(this,
+            new AccessCredentialReceivedEventArgs(
+                accessPoint, new TestCredentialReceivedHandler(cardID)));
+
 
     }
 


### PR DESCRIPTION
Hi Jonathan,

Here is my first pull request. 

This is not for merging into the Aporta developer repository, but just for feedback.

Lots of praying on my part to be able to understand the Aporta code base and make changes! So far, things are coming along well enough, and I have been able to look at your existing code to understand where to make the changes.

The virtual device driver configuration razor page currently has a badge number ("12345") hard coded for testing.

I spent the last couple of hours today struggling to try to figure out how to reference a textbox from Blazor, to be able to determine the badge number keyed in by the user on the Virtual driver configuration page! I still don't have a working solution to that.

After lots of searching on the internet, one solution I tried was referencing Microsoft.JSInterop. This library is supposed to let you reference the webpage DOM. My first attempts using JSInterop did not work. Do you know of a better solution?


Thank you so much again! I am really enjoying working on this project!

- Chris
